### PR TITLE
Add usage part to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $pip install -i https://test.pypi.org/simple/ city-ticketmaster
 
 ## Usage
 
-- TODO
+This package can be used to pull requests and save their own dataframes from the Ticket Master API.
 
 ## Contributing
 


### PR DESCRIPTION
There is nothing under the Usage section, so I add the usage of this API in the README file.