### PR TITLE
add comment to the request result

### DIFF
--- a/src/city_ticketmaster/city_ticketmaster.py
+++ b/src/city_ticketmaster/city_ticketmaster.py
@@ -35,6 +35,10 @@ def apiget(password, city, keyword = ""):
         
         assert r.status_code == 200, "Uh oh, there was an issue with the server. Please doublecheck your input."
         test_json=r.json()
+        
+        """
+        Print the request result
+        """
         try:
                 objectids= test_json['_embedded']
                 return pd.DataFrame(objectids['events'])


### PR DESCRIPTION
In the first function, I add a comment to the print step to help understand the print-result step of apiget.